### PR TITLE
Move deployment to Cloudflare Pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,11 +3,12 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://xkonti.github.io',
-	base: '/NimForUE-docs',
+	site: import.meta.env['SITE_URL'] ?? undefined,
 	integrations: [
 		starlight({
-			title: 'NimForUE documentation',
+			title: import.meta.env['DEPLOYMENT_ENV'] === 'prod'
+				? 'NimForUE'
+				: `NimForUE - ${import.meta.env['DEPLOYMENT_ENV'] ?? 'dev'}`,
 			description: 'NimForUE is a Nim language wrapper for Unreal Engine 5',
 			logo: {
 				src: './src/assets/logo_nimforue.png',

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,9 +6,9 @@ export default defineConfig({
 	site: import.meta.env['SITE_URL'] ?? undefined,
 	integrations: [
 		starlight({
-			title: import.meta.env['DEPLOYMENT_ENV'] === 'prod'
+			title: process.env['DEPLOYMENT_ENV'] === 'prod'
 				? 'NimForUE'
-				: `NimForUE - ${import.meta.env['DEPLOYMENT_ENV'] ?? 'dev'}`,
+				: `NimForUE - ${process.env['DEPLOYMENT_ENV'] ?? 'dev'}`,
 			description: 'NimForUE is a Nim language wrapper for Unreal Engine 5',
 			logo: {
 				src: './src/assets/logo_nimforue.png',

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -7,7 +7,7 @@ hero:
     file: ../../assets/logo_nimforue.png
   actions:
     - text: Get started
-      link: /NimForUE-docs/start/introduction/
+      link: /start/introduction/
       icon: right-arrow
       variant: primary
     - text: NimForUE on GitHub


### PR DESCRIPTION
- This way the docs can have more user-friendly URL: [nimforue.pages.dev](https://nimforue.pages.dev)
- Additionally Cloudflare Pages automatically creates preview deployments for PRs making it easy to check if project still builds and view what the changes look like